### PR TITLE
Corrected No SIM card notification text to the actual one used on W8 wit...

### DIFF
--- a/res/values-dk/strings.xml
+++ b/res/values-dk/strings.xml
@@ -21,11 +21,11 @@
     <string name="reboot_required">Ændringen træder i kraft efter genstart</string>
 
     <string name="signal_icon_autohide_title">Skjul signalstyrkeikoner automatisk</string>
-    <string name="signal_icon_autohide_summary">Skjuler automatisk signalstyrkeikoner for de valgte SIM slots når der ikke er isat SIM kort, \"SIM ikke isat\" notifikationer slået fra</string>
+    <string name="signal_icon_autohide_summary">Skjuler automatisk signalstyrkeikoner for de valgte SIM slots når der ikke er isat SIM kort, \"No SIM card detected\" notifikationer slået fra</string>
     <string name="sim_slot_1">Skjul automatisk for SIM slot 1</string>
     <string name="sim_slot_2">Skjul automatisk for SIM slot 2</string>
     <string name="sim_disable_notifications">Slå notifikationer fra</string>
-    <string name="sim_disable_notifications_summary">\"SIM ikke isat\" notifikationer slået fra</string>
+    <string name="sim_disable_notifications_summary">\"No SIM card detected\" notifikationer slået fra</string>
 
     <string name="poweroff_advanced_title">Udvidet Power-Off menu</string>
     <string name="poweroff_advanced_summary">Aktiverer udvidet Power-Off menu med menupunkt for reboot til systemgendannelse</string>


### PR DESCRIPTION
...h Danish language selected

Hi,

here's the Danish language file with the 'No SIM' notification displayed on my 16GB W8 (which is not translated btw)

T.
