### PR TITLE
corrected Danish text for Torch on/off

### DIFF
--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -65,8 +65,8 @@
     <string name="quick_settings_sync_off">Synkronisering fra</string>
     <string name="quick_settings_wifi_ap_on">Wi-Fi AP til</string>
     <string name="quick_settings_wifi_ap_off">Wi-Fi AP fra</string>
-    <string name="quick_settings_torch_on">Tænd lygte</string>
-    <string name="quick_settings_torch_off">Sluk lygte</string>
+    <string name="quick_settings_torch_on">Lygte tændt</string>
+    <string name="quick_settings_torch_off">Lygte slukket</string>
     <string name="quick_settings_torch_off_notif">Tryk for at slukke</string>
 
     <!--  QuickSettings settings -->


### PR DESCRIPTION
Note to self: Not the action 'turn torch on/off', but the current status of torch.
