### PR TITLE
Updated French translation

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -8,6 +8,7 @@
     <string name="battery_style_stock">Incateur par défaut</string>
     <string name="battery_style_circle">Cercle avec pourcentage</string>
     <string name="battery_style_percent">Texte uniquement</string>
+    <string name="battery_style_percent_stock">Texte et indicateur par défaut</string>
     <string name="battery_style_none">Aucun</string>
 
     <string name="vol_music_controls_title">Touches de volume et pistes audio</string>
@@ -42,7 +43,7 @@
     <string name="recents_clear_all_summary">Active un bouton unique pour supprimer toutes les tâches dans la liste des applications récentes</string>
 
     <string name="fix_datetime_crash_title">Paramètre Date et heure</string>
-    <string name="fix_datetime_crash_summary">Activer si vous constatez un plantage lorsque vous accédez au paramètres Date et heure (redémarrage nécessaire)</string>
+    <string name="fix_datetime_crash_summary">Activer si vous constatez un plantage lorsque vous accédez au paramètre Date et heure (redémarrage nécessaire)</string>
 
     <string name="fix_caller_id_phone_title">Identification de l\'appelant en téléphonie</string>
     <string name="fix_caller_id_phone_summary">Activer si vous constatez qu\'un contact enregistré n\'est pas identifié lord d\'un appel entrant (redémarrage nécessaire)</string>


### PR DESCRIPTION
- Forgotten "Large percent text with stock icon" translation
- One small correction ("s")
