### PR TITLE
Added Danish translation for strings added in 1.5.0

### DIFF
--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -164,4 +164,60 @@
     <string name="pref_flashing_led_disable_title">Slå lysdiodeblink fra</string>
     <string name="pref_flashing_led_disable_summary">Fjerner forstyrrende lysdiodeblink når batteristanden er lav og der ikke lades</string>
 
+    <!-- Display tweaks category -->
+    <string name="pref_cat_display_title">Skærm-tweaks</string>
+    <string name="pref_cat_display_summary">Indeholder diverse skærm-tweaks</string>
+
+    <!-- Minimum brightness level -->
+    <string name="pref_brightness_min_title">Minimumsniveau for lysstyrke</string>
+    <string name="pref_brightness_min_summary">Muliggør angivelse af minimumsniveau for lysstyrke. Påvirker manuel lysstyrke-indstilling. (kræver genstart)</string>
+    <string name="pref_brightness_dlg_msg">Værdi i intervallet: 20 &#8211; 80</string>
+
+    <!--  Autobrightness levels -->
+    <string name="pref_ab_title">Niveauer for automatisk lysstyrke</string>
+    <string name="pref_ab_summary">Tillader at indstille omgivelses-lysniveau og tilhørende værdier for LCD-baggrundslys</string>
+    <string name="level">Niveau</string>
+    <string name="pref_ab_lux_max_label">Lux maks.</string>
+    <string name="pref_ab_brighness_label">Lysstyrke (20 &#8211; 255)</string>
+    <string name="pref_ab_number_error_general">Angivet tal er ugyldigt</string>
+    <string name="pref_ab_brightness_too_low">Det anbefales ikke at sætte lysstyrke til under 20</string>
+    <string name="pref_ab_brightness_too_high">Lysstyrke kan højst være 255</string>
+    <string name="pref_ab_number_error_negative">Værdier kan ikke være mindre end nul</string>
+    <string name="pref_ab_number_not_ascending">Værdier for lavere niveauer kan ikke være større end værdier for højere niveauer</string>
+    <string name="pref_ab_number_not_descending">Værdier for højere niveauer kan ikke være mindre end værdier for lavere niveauer</string>
+    <string name="pref_ab_values_set">Værdier for %s indstillet</string>
+    <string name="pref_ab_config_saved">Ny konfiguration for automatisk lysstyrke gemt</string>
+    <string name="pref_ab_config_cancelled">Konfiguration for automatisk lysstyrke IKKE gemt</string>
+
+    <!-- Lockscreen rotation -->
+    <string name="pref_lockscreen_rotation_title">Rotation af låseskærm til</string>
+    <string name="pref_lockscreen_rotation_summary">ADVARSEL: Kan flytte rundt på mål på lås-op-ringen på nogle apparater såfremt AOSP låseskærmen er ændret af sælger</string>
+
+    <!-- Lockscreen menu key -->
+    <string name="pref_lockscreen_menu_key_title">Oplåsning med menu-tast til</string>
+    <string name="pref_lockscreen_menu_key_summary">Menu-tasten kan benyttes til hurtig oplåsning af apparatet når låseskærmen vises (kræver genstart)</string>
+
+    <!-- Fix messaging wakelock -->
+    <string name="pref_mms_fix_wakelock_title">Fix besked-opvågning</string>
+    <string name="pref_mms_fix_wakelock_summary">Forhindrer at skærmen tændes når ny besked ankommer (kræver genstart)</string>
+
+    <!-- Statusbar center clock -->
+    <string name="pref_statusbar_center_clock_title">Ur i midten</string>
+
+    <!-- Media tweaks category -->
+    <string name="pref_cat_media_title">Medie-tweaks</string>
+    <string name="pref_cat_media_summary">Indeholder diverse tweaks for medie- og lydsystem</string>
+
+    <!-- More music volume steps -->
+    <string name="pref_music_volume_steps_title">Flere lydstyrkeniveauer</string>
+    <string name="pref_music_volume_steps_summary">Tilføjer flere lydstyrketrin for musikstrøm (kræver genstart) </string>
+
+    <!-- Safe headset media volume -->
+    <string name="pref_safe_media_volume_title">Sikkert lydniveau for hovedtelefoner</string>
+    <string name="pref_safe_media_volume_summary">Slår sikkert lydniveau for hovedtelefoner til eller fra</string>
+
+    <!-- Disable charging LED -->
+    <string name="pref_charging_led_disable_title">Afbryd lade-LED</string>
+    <string name="pref_charging_led_disable_summary">Afbryder lysdiodesignal for ladning</string>
+
 </resources>


### PR DESCRIPTION
Is this what you mean by 'vacation'? :P

I took the liberty of assuming no changes in previously existing strings, i.e. have only translated from line 167 and onwards. Let me know if my assumption is wrong.

This time I did not try so hard to preserve your exact wording (but of course the meaning of the words). This was to avoid unneccesarily long Germanesque sentences (not on account of your choice of words, but sometimes literal translations become awkward).

Why 'by vendor'? Does it matter who modified the AOSP lockscreen?
