### PR TITLE
Reorganized lockscreen tweaks category

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -526,13 +526,13 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Screenshot v menu napájení</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Zkratky obrazovky uzamčení</string>
-    <string name="pref_lockscreen_targets_enable_title">Povolit zkratky</string>
-    <string name="pref_lockscreen_targets_enable_summary">Hlavní vypínač pro zkratky obrazovky uzamčení</string>
-    <string name="pref_lockscreen_targets_app_title">Aplikace pro zkratku %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Vertikální ofset prstence</string>
-    <string name="pref_lockscreen_targets_right_offset_title">Horizontální ofset prstence</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Zkratky obrazovky uzamčení</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Povolit zkratky</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Hlavní vypínač pro zkratky obrazovky uzamčení</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplikace pro zkratku %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Vertikální ofset prstence</string>
+    <string name="pref_lockscreen_ring_horizontal_offset_title">Horizontální ofset prstence</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Povolit ovládání jasu</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -528,12 +528,12 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Captura de pantalla en el menú de apagado</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Objetivos en pantalla de bloqueo</string>
-    <string name="pref_lockscreen_targets_enable_title">Habilitar objetivos en pantalla de bloqueo</string>
-    <string name="pref_lockscreen_targets_enable_summary">Switch principal para objetivos en pantalla de bloqueo</string>
-    <string name="pref_lockscreen_targets_app_title">Aplicación del objetivo %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Offset del anillo de desbloqueo</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Objetivos en pantalla de bloqueo</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Habilitar objetivos en pantalla de bloqueo</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Switch principal para objetivos en pantalla de bloqueo</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplicación del objetivo %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Offset del anillo de desbloqueo</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Habilitar control de brillo</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -529,13 +529,13 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Capture d\'écran dans le menu d\'extinction</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Cibles de l\'écran de déverrouillage</string>
-    <string name="pref_lockscreen_targets_enable_title">Activer les cibles de l\'écran de déverrouillage</string>
-    <string name="pref_lockscreen_targets_enable_summary">Interrupteur général pour les cibles de l\'écran de déverrouillage</string>
-    <string name="pref_lockscreen_targets_app_title">Application cible %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Marge verticale anneau de déverrouillage</string>
-    <string name="pref_lockscreen_targets_right_offset_title">Marge horizontale anneau de déverrouillage</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Cibles de l\'écran de déverrouillage</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Activer les cibles de l\'écran de déverrouillage</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Interrupteur général pour les cibles de l\'écran de déverrouillage</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Application cible %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Marge verticale anneau de déverrouillage</string>
+    <string name="pref_lockscreen_ring_horizontal_offset_title">Marge horizontale anneau de déverrouillage</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Activer le contrôle de la luminosité</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -527,12 +527,12 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Screenshot di menu power</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Target Lockscreen</string>
-    <string name="pref_lockscreen_targets_enable_title">Hidupkan target lockscreen</string>
-    <string name="pref_lockscreen_targets_enable_summary">Hidupkan pengaturan target lockscreen</string>
-    <string name="pref_lockscreen_targets_app_title">Aplikasi target %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Jarak bawah cincin unlock</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Target Lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Hidupkan target lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Hidupkan pengaturan target lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplikasi target %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Jarak bawah cincin unlock</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Hidupkan kontrol kecerahan</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -515,12 +515,12 @@
  <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Abilita Fotografa schermo nel menu apegnimento</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Applicazioni in Lockscreen</string>
-    <string name="pref_lockscreen_targets_enable_title">Abilita app in lockscreen</string>
-    <string name="pref_lockscreen_targets_enable_summary">Attivazione Applicazioni in Lockscreen</string>
-    <string name="pref_lockscreen_targets_app_title">Applicazione %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Scostamento dell\'anello di sblocco, margine inferiore</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Applicazioni in Lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Abilita app in lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Attivazione Applicazioni in Lockscreen</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Applicazione %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Scostamento dell\'anello di sblocco, margine inferiore</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Abilita controllo luminosità</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -343,11 +343,11 @@
     <string name="pref_navbar_width_summary">Dotyczy orientacji poziomej</string>
     <string name="pref_navbar_menukey_title">Zawsze pokazuj klawisz menu</string>
     <string name="pref_powermenu_screenshot_title">Zrzut ekranu w menu zasilania</string>
-    <string name="pref_cat_lockscreen_targets_title">Cele Ekranu Blokady</string>
-    <string name="pref_lockscreen_targets_enable_title">Włącz Cele Ekranu blokady</string>
-    <string name="pref_lockscreen_targets_enable_summary">Główny wyłącznik Celów Ekranu Blokady</string>
-    <string name="pref_lockscreen_targets_app_title">Aplikacja docelowa %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Przesunięcie pierścienia odblokowania</string>
+    <string name="pref_cat_lockscreen_ring_settings_title">Cele Ekranu Blokady</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Włącz Cele Ekranu blokady</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Główny wyłącznik Celów Ekranu Blokady</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplikacja docelowa %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Przesunięcie pierścienia odblokowania</string>
     <string name="pref_statusbar_brightness_title">Włącz kontrolę jasności</string>
     <string name="pref_statusbar_brightness_summary">Regulacja jasności przy przesuwaniu palcem na pasku stanu</string>
     <string name="pref_cat_phone_telephony_title">Telefon</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -529,13 +529,13 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Captura de ecrã no Menu Desligar</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Alvos do anel de desbloqueio</string>
-    <string name="pref_lockscreen_targets_enable_title">Ativar alvos do anel de desbloqueio</string>
-    <string name="pref_lockscreen_targets_enable_summary">Permite definir até cinco aplicações como alvo no anel de desbloqueio</string>
-    <string name="pref_lockscreen_targets_app_title">Aplicação %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Desvio vertical do anel de desbloqueio</string>
-    <string name="pref_lockscreen_targets_right_offset_title">Desvio horizontal do anel de desbloqueio</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Definições do anel de desbloqueio</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Ativar alvos do anel de desbloqueio</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Permite definir até cinco aplicações como alvo no anel de desbloqueio</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplicação %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Desvio vertical do anel de desbloqueio</string>
+    <string name="pref_lockscreen_ring_horizontal_offset_title">Desvio horizontal do anel de desbloqueio</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Ativar controlo de brilho</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -527,12 +527,12 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Скриншот в меню выключения</string>
     
-	<!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Цели экрана блокировки</string>
-    <string name="pref_lockscreen_targets_enable_title">Включить цели экрана блокировки</string>
-    <string name="pref_lockscreen_targets_enable_summary">Общий переключатель целей экрана блокировки</string>
-    <string name="pref_lockscreen_targets_app_title">Целевое приложение %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Нижнее смещение кольца разблокировки</string>
+	<!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Цели экрана блокировки</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Включить цели экрана блокировки</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Общий переключатель целей экрана блокировки</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Целевое приложение %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Нижнее смещение кольца разблокировки</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Включить контроль яркости</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -522,13 +522,13 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Screenshot v menu napájania</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Skratky obrazovky uzamknutia</string>
-    <string name="pref_lockscreen_targets_enable_title">Povoliť skratky</string>
-    <string name="pref_lockscreen_targets_enable_summary">Hlavný vypínač pre skratky obrazovky uzamknutia</string>
-    <string name="pref_lockscreen_targets_app_title">Aplikácia pre skratku %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Vertikálny ofset prstenca</string>
-    <string name="pref_lockscreen_targets_right_offset_title">Horizontálny ofset prstenca</string> 
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Skratky obrazovky uzamknutia</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Povoliť skratky</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Hlavný vypínač pre skratky obrazovky uzamknutia</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Aplikácia pre skratku %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Vertikálny ofset prstenca</string>
+    <string name="pref_lockscreen_ring_horizontal_offset_title">Horizontálny ofset prstenca</string> 
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Povoliť ovládanie jasu</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -524,12 +524,12 @@
     <string name="pref_powermenu_screenshot_title">電源選單顯示螢幕截圖</string>
 
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">螢幕鎖定目標</string>
-    <string name="pref_lockscreen_targets_enable_title">啟用螢幕鎖定目標</string>
-    <string name="pref_lockscreen_targets_enable_summary">鎖定螢幕滑動主滑動</string>
-    <string name="pref_lockscreen_targets_app_title">目標應用程式 %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">解鎖環底部偏移</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">螢幕鎖定目標</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">啟用螢幕鎖定目標</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">鎖定螢幕滑動主滑動</string>
+    <string name="pref_lockscreen_ring_targets_app_title">目標應用程式 %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">解鎖環底部偏移</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">啟用亮度控制</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -529,13 +529,13 @@
     <!-- Screenshot in power menu -->
     <string name="pref_powermenu_screenshot_title">Screenshot in power menu</string>
 
-    <!-- Lockscreen targets -->
-    <string name="pref_cat_lockscreen_targets_title">Lockscreen targets</string>
-    <string name="pref_lockscreen_targets_enable_title">Enable lockscreen targets</string>
-    <string name="pref_lockscreen_targets_enable_summary">Master switch for lockscreen targets</string>
-    <string name="pref_lockscreen_targets_app_title">Target application %s</string>
-    <string name="pref_lockscreen_targets_bottom_offset_title">Unlock ring vertical offset</string>
-    <string name="pref_lockscreen_targets_right_offset_title">Unlock ring horizontal offset</string>
+    <!-- Unlock ring settings -->
+    <string name="pref_cat_lockscreen_ring_settings_title">Unlock ring settings</string>
+    <string name="pref_lockscreen_ring_targets_enable_title">Enable unlock ring targets</string>
+    <string name="pref_lockscreen_ring_targets_enable_summary">Master switch for unlock ring targets</string>
+    <string name="pref_lockscreen_ring_targets_app_title">Target application %s</string>
+    <string name="pref_lockscreen_ring_vertical_offset_title">Unlock ring vertical offset</string>
+    <string name="pref_lockscreen_ring_horizontal_offset_title">Unlock ring horizontal offset</string>
 
     <!-- Statusbar brightness control -->
     <string name="pref_statusbar_brightness_title">Enable brightness control</string>

--- a/res/xml/gravitybox.xml
+++ b/res/xml/gravitybox.xml
@@ -7,43 +7,43 @@
         android:summary="@string/pref_cat_lockscreen_summary">
 
         <PreferenceScreen 
-            android:key="pref_cat_lockscreen_targets"
-            android:title="@string/pref_cat_lockscreen_targets_title">
+            android:key="pref_cat_lockscreen_ring_settings"
+            android:title="@string/pref_cat_lockscreen_ring_settings_title">
 
             <CheckBoxPreference 
-                android:key="pref_lockscreen_targets_enable"
-                android:title="@string/pref_lockscreen_targets_enable_title"
-                android:summary="@string/pref_lockscreen_targets_enable_summary"
+                android:key="pref_lockscreen_ring_targets_enable"
+                android:title="@string/pref_lockscreen_ring_targets_enable_title"
+                android:summary="@string/pref_lockscreen_ring_targets_enable_summary"
                 android:defaultValue="false" />
 
             <com.ceco.gm2.gravitybox.preference.AppPickerPreference
-                android:key="pref_lockscreen_targets_app0"
-                android:title="@string/pref_lockscreen_targets_app_title"
+                android:key="pref_lockscreen_ring_targets_app0"
+                android:title="@string/pref_lockscreen_ring_targets_app_title"
                 android:summary="@string/app_picker_none" />
 
             <com.ceco.gm2.gravitybox.preference.AppPickerPreference
-                android:key="pref_lockscreen_targets_app1"
-                android:title="@string/pref_lockscreen_targets_app_title"
+                android:key="pref_lockscreen_ring_targets_app1"
+                android:title="@string/pref_lockscreen_ring_targets_app_title"
                 android:summary="@string/app_picker_none" />
 
             <com.ceco.gm2.gravitybox.preference.AppPickerPreference
-                android:key="pref_lockscreen_targets_app2"
-                android:title="@string/pref_lockscreen_targets_app_title"
+                android:key="pref_lockscreen_ring_targets_app2"
+                android:title="@string/pref_lockscreen_ring_targets_app_title"
                 android:summary="@string/app_picker_none" />
 
             <com.ceco.gm2.gravitybox.preference.AppPickerPreference
-                android:key="pref_lockscreen_targets_app3"
-                android:title="@string/pref_lockscreen_targets_app_title"
+                android:key="pref_lockscreen_ring_targets_app3"
+                android:title="@string/pref_lockscreen_ring_targets_app_title"
                 android:summary="@string/app_picker_none" />
 
             <com.ceco.gm2.gravitybox.preference.AppPickerPreference
-                android:key="pref_lockscreen_targets_app4"
-                android:title="@string/pref_lockscreen_targets_app_title"
+                android:key="pref_lockscreen_ring_targets_app4"
+                android:title="@string/pref_lockscreen_ring_targets_app_title"
                 android:summary="@string/app_picker_none" />
 
             <com.ceco.gm2.gravitybox.preference.SeekBarPreference
-                android:key="pref_lockscreen_targets_bottom_offset2"
-                android:title="@string/pref_lockscreen_targets_bottom_offset_title"
+                android:key="pref_lockscreen_ring_targets_vertical_offset"
+                android:title="@string/pref_lockscreen_ring_vertical_offset_title"
                 minimum="-50"
                 maximum="50"
                 interval="1"
@@ -52,8 +52,8 @@
                 android:defaultValue="0" />
 
             <com.ceco.gm2.gravitybox.preference.SeekBarPreference
-                android:key="pref_lockscreen_targets_right_offset2"
-                android:title="@string/pref_lockscreen_targets_right_offset_title"
+                android:key="pref_lockscreen_ring_targets_horizontal_offset"
+                android:title="@string/pref_lockscreen_ring_horizontal_offset_title"
                 minimum="-30"
                 maximum="30"
                 interval="1"

--- a/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
+++ b/src/com/ceco/gm2/gravitybox/GravityBoxSettings.java
@@ -314,13 +314,13 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
     public static final String EXTRA_NAVBAR_WIDTH = "navbarWidth";
     public static final String EXTRA_NAVBAR_MENUKEY = "navbarMenukey";
 
-    public static final String PREF_KEY_LOCKSCREEN_TARGETS_ENABLE = "pref_lockscreen_targets_enable";
+    public static final String PREF_KEY_LOCKSCREEN_TARGETS_ENABLE = "pref_lockscreen_ring_targets_enable";
     public static final String PREF_KEY_LOCKSCREEN_TARGETS_APP[] = new String[] {
-        "pref_lockscreen_targets_app0", "pref_lockscreen_targets_app1", "pref_lockscreen_targets_app2",
-        "pref_lockscreen_targets_app3", "pref_lockscreen_targets_app4"
+        "pref_lockscreen_ring_targets_app0", "pref_lockscreen_ring_targets_app1", "pref_lockscreen_ring_targets_app2",
+        "pref_lockscreen_ring_targets_app3", "pref_lockscreen_ring_targets_app4"
     };
-    public static final String PREF_KEY_LOCKSCREEN_TARGETS_BOTTOM_OFFSET = "pref_lockscreen_targets_bottom_offset2";
-    public static final String PREF_KEY_LOCKSCREEN_TARGETS_RIGHT_OFFSET = "pref_lockscreen_targets_right_offset2";
+    public static final String PREF_KEY_LOCKSCREEN_TARGETS_VERTICAL_OFFSET = "pref_lockscreen_ring_targets_vertical_offset";
+    public static final String PREF_KEY_LOCKSCREEN_TARGETS_HORIZONTAL_OFFSET = "pref_lockscreen_ring_targets_horizontal_offset";
 
     public static final String PREF_KEY_STATUSBAR_BRIGHTNESS = "pref_statusbar_brightness";
     public static final String ACTION_PREF_STATUSBAR_BRIGHTNESS_CHANGED = "gravitybox.intent.action.STATUSBAR_BRIGHTNESS_CHANGED";
@@ -559,8 +559,8 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
         private CheckBoxPreference mPrefNavbarMenukey;
         private CheckBoxPreference mPrefMusicVolumeSteps;
         private AppPickerPreference[] mPrefLockscreenTargetsApp;
-        private SeekBarPreference mPrefLockscreenTargetsBottomOffset;
-        private SeekBarPreference mPrefLockscreenTargetsRightOffset;
+        private SeekBarPreference mPrefLockscreenTargetsVerticalOffset;
+        private SeekBarPreference mPrefLockscreenTargetsHorizontalOffset;
         private CheckBoxPreference mPrefMobileDataSlow2gDisable;
         private PreferenceCategory mPrefCatPhoneTelephony;
         private PreferenceCategory mPrefCatPhoneMobileData;
@@ -700,14 +700,14 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
                 mPrefLockscreenTargetsApp[i] = (AppPickerPreference) findPreference(
                         PREF_KEY_LOCKSCREEN_TARGETS_APP[i]);
                 String title = String.format(
-                        getString(R.string.pref_lockscreen_targets_app_title), (i+1));
+                        getString(R.string.pref_lockscreen_ring_targets_app_title), (i+1));
                 mPrefLockscreenTargetsApp[i].setTitle(title);
                 mPrefLockscreenTargetsApp[i].setDialogTitle(title);
             }
-            mPrefLockscreenTargetsBottomOffset = (SeekBarPreference) findPreference(
-                    PREF_KEY_LOCKSCREEN_TARGETS_BOTTOM_OFFSET);
-            mPrefLockscreenTargetsRightOffset = (SeekBarPreference) findPreference(
-                    PREF_KEY_LOCKSCREEN_TARGETS_RIGHT_OFFSET);
+            mPrefLockscreenTargetsVerticalOffset = (SeekBarPreference) findPreference(
+                    PREF_KEY_LOCKSCREEN_TARGETS_VERTICAL_OFFSET);
+            mPrefLockscreenTargetsHorizontalOffset = (SeekBarPreference) findPreference(
+                    PREF_KEY_LOCKSCREEN_TARGETS_HORIZONTAL_OFFSET);
 
             mPrefCatPhoneTelephony = (PreferenceCategory) findPreference(PREF_CAT_KEY_PHONE_TELEPHONY);
             mPrefCatPhoneMobileData = (PreferenceCategory) findPreference(PREF_CAT_KEY_PHONE_MOBILE_DATA);
@@ -960,9 +960,9 @@ public class GravityBoxSettings extends Activity implements GravityBoxResultRece
                 for(Preference p : mPrefLockscreenTargetsApp) {
                     p.setEnabled(enabled);
                 }
-                mPrefLockscreenTargetsBottomOffset.setEnabled(enabled);
-                mPrefLockscreenTargetsRightOffset.setEnabled(enabled);
             }
+            mPrefLockscreenTargetsVerticalOffset.setEnabled(true);
+            mPrefLockscreenTargetsHorizontalOffset.setEnabled(true);
 
             if (key == null || key.equals(PREF_KEY_NETWORK_MODE_TILE_MODE)) {
                 mPrefNetworkModeTileMode.setSummary(mPrefNetworkModeTileMode.getEntry());

--- a/src/com/ceco/gm2/gravitybox/ModLockscreen.java
+++ b/src/com/ceco/gm2/gravitybox/ModLockscreen.java
@@ -172,8 +172,6 @@ public class ModLockscreen {
                 protected void afterHookedMethod(final MethodHookParam param) throws Throwable {
                     if (DEBUG) log("KeyGuardSelectorView onFinishInflate()");
                     prefs.reload();
-                    if (!prefs.getBoolean(
-                            GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_ENABLE, false)) return;
 
                     final Context context = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
                     final Resources res = context.getResources();
@@ -183,10 +181,10 @@ public class ModLockscreen {
                     try {
                         final FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) gpView.getLayoutParams();
                         final int bottomMarginOffsetPx = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 
-                                prefs.getInt(GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_BOTTOM_OFFSET, 0),
+                                prefs.getInt(GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_VERTICAL_OFFSET, 0),
                                 res.getDisplayMetrics());
                         final int rightMarginOffsetPx = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 
-                                prefs.getInt(GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_RIGHT_OFFSET, 0),
+                                prefs.getInt(GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_HORIZONTAL_OFFSET, 0),
                                 res.getDisplayMetrics());
                         lp.setMargins(lp.leftMargin, lp.topMargin, lp.rightMargin - rightMarginOffsetPx, 
                                 lp.bottomMargin - bottomMarginOffsetPx);
@@ -194,6 +192,9 @@ public class ModLockscreen {
                     } catch (Throwable t) {
                         log("Lockscreen targets: error while trying to modify GlowPadView layout" + t.getMessage());
                     }
+
+                    if (!prefs.getBoolean(
+                            GravityBoxSettings.PREF_KEY_LOCKSCREEN_TARGETS_ENABLE, false)) return;
 
                     @SuppressWarnings("unchecked")
                     final ArrayList<Object> targets = (ArrayList<Object>) XposedHelpers.getObjectField(


### PR DESCRIPTION
- "Lockscreen targets" renamed to "Unlock ring settings"
  because already contained more than just the setup of custom targets
- Vertical and horizontal offset can now be adjusted even if
  custom targets are not enabled
